### PR TITLE
Rename customer_id column in rfm-table-transaction.R

### DIFF
--- a/R/rfm-table-transaction.R
+++ b/R/rfm-table-transaction.R
@@ -64,7 +64,8 @@ rfm_table_order.default <- function(data = NULL, customer_id = NULL,
   other_cols <-
     data %>%
     select(!c({{ order_date }}, {{ revenue }})) %>%
-    distinct()
+    distinct() %>%
+    rename(customer_id = {{ customer_id }})
 
   out <- rfm_prep_bins(
     result, recency_bins, frequency_bins, monetary_bins,


### PR DESCRIPTION
I was getting an error whenever I ran rfm_table_order(); as it turns out, the issue was at a join in rfm_prep_bins(). The data frame "other_cols" passed to argument "data" did not have a column named "customer_id", so it couldn't be used as a join key and the function would crash.

In order to solve the issue, I renamed the customer ID column in "other_cols" with rfm_table_order.default()